### PR TITLE
Update kmp

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -12,15 +12,23 @@ OBJECTS = $(SOURCES:.cpp=.o)
 # Executável
 TARGET = programa
 
+# Regra padrão
 all: $(TARGET)
 
+# Linkagem
 $(TARGET): $(OBJECTS)
 	$(CXX) $(CXXFLAGS) -o $@ $^
 
+# Compilação de .cpp para .o
 %.o: %.cpp $(HEADERS)
 	$(CXX) $(CXXFLAGS) -c $< -o $@
 
+# Regra para rodar o programa
+run: $(TARGET)
+	./$(TARGET)
+
+# Limpeza
 clean:
 	rm -f $(OBJECTS) $(TARGET)
 
-.PHONY: all clean
+.PHONY: all clean run

--- a/kmp.cpp
+++ b/kmp.cpp
@@ -4,9 +4,9 @@
 using namespace std;
 
 // Função que constroi vetor de prefixos
-std::vector<int> construirPrefixo(const std::string& padrao) {
+std::vector<size_t> construirPrefixo(const std::string& padrao) {
     int m = padrao.length(), j = 0;
-    vector<int> prefixo(m);
+    vector<size_t> prefixo(m);
     
     for (int i = 1; i < m; i++) {
         while (j > 0 && padrao[i] != padrao[j])
@@ -20,12 +20,12 @@ std::vector<int> construirPrefixo(const std::string& padrao) {
 }
 
 // Função KMP
-std::vector<int> buscarKMP(const std::string& texto, const std::string& padrao) {
-    vector<int> posicoes;
-    vector<int> prefixo = construirPrefixo(padrao);
-    int j = 0;
+std::vector<size_t> buscarKMP(const std::string& texto, const std::string& padrao) {
+    vector<size_t> posicoes;
+    vector<size_t> prefixo = construirPrefixo(padrao);
+    size_t j = 0;
 
-    for (int i = 0; i < texto.length(); i++) {
+    for (size_t i = 0; i < texto.length(); i++) {
         while (j > 0 && texto[i] != padrao[j])
             j = prefixo[j - 1];
         if (texto[i] == padrao[j])

--- a/kmp.cpp
+++ b/kmp.cpp
@@ -71,9 +71,11 @@ std::vector<size_t> buscarKMP(const std::string& texto, const std::string& padra
     
     vector<size_t> posicoes;
     vector<size_t> prefixo = construirPrefixo(pattern);
-    size_t j = 0;
+    size_t j = 0, n = text.length(), total_ocorrencias = 0;
 
-    for (size_t i = 0; i < text.length(); i++) {
+    posicoes.reserve(20);   // reserva 20 espaços de memória para guardar as posições encontradas. Isso evita de ficar dobrando o vector a cada nova palavra encontrada. O(n) -> O(1) para as 20 primeiras posições
+
+    for (size_t i = 0; i < n; i++) {
         while (j > 0 && text[i] != pattern[j])
             j = prefixo[j - 1];
 
@@ -84,8 +86,11 @@ std::vector<size_t> buscarKMP(const std::string& texto, const std::string& padra
             size_t pos = i - j + 1;
             posicoes.push_back(pos);
             j = prefixo[j - 1];
+            total_ocorrencias++;
         }
     }
- 
+
+    cout << "\nNúmero total de ocorrências desta palavra: " << total_ocorrencias << endl;
+
     return posicoes;
 }

--- a/kmp.cpp
+++ b/kmp.cpp
@@ -4,6 +4,27 @@
 
 using namespace std;
 
+// Função que transforma a string em minúscula
+string paraMinusculo(const string& s) {
+    string resultado = s;
+
+    for (size_t i = 0; i < resultado.size(); i++) {
+        char c = resultado[i];
+        
+        /* Em ASCII:
+            -  letras maiúsculas vão do 'A' (65) até 'Z' (90)
+            -  letras minúsculas vão do 'a' (97) até 'z' (122)
+
+            A diferença entre maiúscula e minúscula é 32, então somando 32 ao caractere, é encontrada sua versão minúsucla
+        */
+    
+        if (c >= 'A' && c <= 'Z') {
+            resultado[i] = c + 32;
+        }
+    }
+    return resultado;    
+}
+
 // Função que constroi vetor de prefixos
 std::vector<size_t> construirPrefixo(const std::string& padrao) {
     vector<size_t> prefixo(padrao.length(), 0);
@@ -22,18 +43,44 @@ std::vector<size_t> construirPrefixo(const std::string& padrao) {
 
 // Função KMP
 std::vector<size_t> buscarKMP(const std::string& texto, const std::string& padrao) {
+
+    // VERIFICAÇÕES INICIAIS DE SEGURANÇA
+    // Se não tiver palavra a ser procurada:
+    if (padrao.empty()) {
+        cout << "\nNão há palavra a ser procurada!" << endl;
+        return {};
+    }
+
+    // Se não tiver texto para procurar a palavra:
+    if (texto.empty()) {
+        cout << "\nNão há texto a ser percorrido!" << endl;
+        return {}; 
+    }
+
+    // Se a palavra a ser procurada for maior que o texto:
+    if (padrao.size() > texto.size()) {
+        cout << "\nA palavra a ser encontrada é maior que o texto!" << endl;
+        return {}; 
+    }
+
+
+    string text, pattern;
+
+    text = paraMinusculo(texto);
+    pattern = paraMinusculo(padrao);
+    
     vector<size_t> posicoes;
-    vector<size_t> prefixo = construirPrefixo(padrao);
+    vector<size_t> prefixo = construirPrefixo(pattern);
     size_t j = 0;
 
-    for (size_t i = 0; i < texto.length(); i++) {
-        while (j > 0 && texto[i] != padrao[j])
+    for (size_t i = 0; i < text.length(); i++) {
+        while (j > 0 && text[i] != pattern[j])
             j = prefixo[j - 1];
 
-        if (texto[i] == padrao[j])
+        if (text[i] == pattern[j])
             j++;
 
-        if (j == padrao.length()) {
+        if (j == pattern.length()) {
             size_t pos = i - j + 1;
             posicoes.push_back(pos);
             j = prefixo[j - 1];

--- a/kmp.cpp
+++ b/kmp.cpp
@@ -1,14 +1,15 @@
 #include <vector>
 #include <string>
+#include <iostream>
 
 using namespace std;
 
 // Função que constroi vetor de prefixos
 std::vector<size_t> construirPrefixo(const std::string& padrao) {
-    int m = padrao.length(), j = 0;
-    vector<size_t> prefixo(m);
+    vector<size_t> prefixo(padrao.length(), 0);
+    size_t j = 0;
     
-    for (int i = 1; i < m; i++) {
+    for (size_t i = 1; i < padrao.length(); i++) {
         while (j > 0 && padrao[i] != padrao[j])
             j = prefixo[j - 1];
         if (padrao[i] == padrao[j])
@@ -28,13 +29,16 @@ std::vector<size_t> buscarKMP(const std::string& texto, const std::string& padra
     for (size_t i = 0; i < texto.length(); i++) {
         while (j > 0 && texto[i] != padrao[j])
             j = prefixo[j - 1];
+
         if (texto[i] == padrao[j])
             j++;
+
         if (j == padrao.length()) {
-            posicoes.push_back(i - j + 1);
+            size_t pos = i - j + 1;
+            posicoes.push_back(pos);
             j = prefixo[j - 1];
         }
     }
-    
+ 
     return posicoes;
 }

--- a/kmp.hpp
+++ b/kmp.hpp
@@ -4,6 +4,6 @@
 #include <string>
 #include <vector>
 
-std::vector<int> buscarKMP(const std::string& texto, const std::string& padrao);
+std::vector<size_t> buscarKMP(const std::string& texto, const std::string& padrao);
 
 #endif

--- a/main.cpp
+++ b/main.cpp
@@ -14,13 +14,13 @@ int main() {
     cout << "Digite a palavra a ser buscada: ";
     getline(cin, palavra);
 
-    vector<int> posicoes = buscarKMP(texto, palavra);
+    vector<size_t> posicoes = buscarKMP(texto, palavra);
 
     if (posicoes.empty()) {
         cout << "Palavra não encontrada no texto." << endl;
     } else {
         cout << "Palavra encontrada nas posições: ";
-        for (int pos : posicoes) {
+        for (size_t pos : posicoes) {
             cout << pos << " ";
         }
         cout << endl;


### PR DESCRIPTION
Alteração dos tipos da variável j, e dos vectors prefixo e posicoes, assim como os retornos das funcoes buscarKMP e construir prefixo :
troca:
int -> size_t

Motivo:
Ao compilar, a comparação de tipos sem sinal (size_t) e com sinal (int) causa warnings.

em:
for (size_t i = 0; i < texto.length(); i++) {
o i que era int era comparado com o metodo .length que retorna um size_t

tambem acontecia para o j